### PR TITLE
chore: use numeric user in Dockerfile

### DIFF
--- a/images/arch/base/base-devel/Dockerfile
+++ b/images/arch/base/base-devel/Dockerfile
@@ -7,7 +7,7 @@ FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 # Copy configuration files to appropriate locations
 COPY files /
@@ -38,4 +38,4 @@ RUN curl --location "https://github.com/docker/compose/releases/download/1.29.2/
     chmod +x /usr/local/bin/docker-compose-switch && \
     ln --symbolic /usr/local/bin/docker-compose-switch /usr/local/bin/docker-compose
 
-USER coder
+USER 1000

--- a/images/arch/base/base/Dockerfile
+++ b/images/arch/base/base/Dockerfile
@@ -7,7 +7,7 @@ FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 # Copy configuration files to appropriate locations
 COPY files /
@@ -38,4 +38,4 @@ RUN curl --location "https://github.com/docker/compose/releases/download/1.29.2/
     chmod +x /usr/local/bin/docker-compose-switch && \
     ln --symbolic /usr/local/bin/docker-compose-switch /usr/local/bin/docker-compose
 
-USER coder
+USER 1000

--- a/images/arch/minimal/base-devel/Dockerfile
+++ b/images/arch/minimal/base-devel/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/archlinux/archlinux:base-devel
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 RUN pacman --noconfirm --needed -Syyuu \
       base \
@@ -21,4 +21,4 @@ RUN useradd coder \
       --uid=1000 \
       --user-group
 
-USER coder
+USER 1000

--- a/images/arch/minimal/base/Dockerfile
+++ b/images/arch/minimal/base/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/archlinux/archlinux:base
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 RUN pacman --noconfirm --needed -Syyuu \
       base \
@@ -21,4 +21,4 @@ RUN useradd coder \
       --uid=1000 \
       --user-group
 
-USER coder
+USER 1000

--- a/images/centos/base/stream8/Dockerfile
+++ b/images/centos/base/stream8/Dockerfile
@@ -7,7 +7,7 @@ FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 # Copy configuration files to appropriate locations
 COPY files /
@@ -39,4 +39,4 @@ RUN curl --location "https://github.com/docker/compose/releases/download/1.29.2/
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-v1 1 && \
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-switch 99
 
-USER coder
+USER 1000

--- a/images/centos/base/stream9/Dockerfile
+++ b/images/centos/base/stream9/Dockerfile
@@ -7,7 +7,7 @@ FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 # Copy configuration files to appropriate locations
 COPY files /
@@ -34,4 +34,4 @@ RUN curl --location "https://github.com/docker/compose/releases/download/1.29.2/
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-v1 1 && \
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-switch 99
 
-USER coder
+USER 1000

--- a/images/centos/minimal/stream8/Dockerfile
+++ b/images/centos/minimal/stream8/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/centos/centos:stream8
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 RUN dnf install --assumeyes --quiet \
       bash \
@@ -19,4 +19,4 @@ RUN useradd coder \
       --uid=1000 \
       --user-group
 
-USER coder
+USER 1000

--- a/images/centos/minimal/stream9/Dockerfile
+++ b/images/centos/minimal/stream9/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/centos/centos:stream9
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 RUN dnf install --assumeyes --quiet \
       bash \
@@ -19,4 +19,4 @@ RUN useradd coder \
       --uid=1000 \
       --user-group
 
-USER coder
+USER 1000

--- a/images/debian/base/bullseye/Dockerfile
+++ b/images/debian/base/bullseye/Dockerfile
@@ -7,7 +7,7 @@ FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 # Copy configuration files to appropriate locations
 COPY files /
@@ -58,4 +58,4 @@ RUN curl --location "https://github.com/docker/compose/releases/download/1.29.2/
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-v1 1 && \
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-switch 99
 
-USER coder
+USER 1000

--- a/images/debian/base/testing/Dockerfile
+++ b/images/debian/base/testing/Dockerfile
@@ -7,7 +7,7 @@ FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 # Copy configuration files to appropriate locations
 COPY files /
@@ -58,4 +58,4 @@ RUN curl --location "https://github.com/docker/compose/releases/download/1.29.2/
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-v1 1 && \
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-switch 99
 
-USER coder
+USER 1000

--- a/images/debian/base/unstable/Dockerfile
+++ b/images/debian/base/unstable/Dockerfile
@@ -7,7 +7,7 @@ FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 # Copy configuration files to appropriate locations
 COPY files /
@@ -58,4 +58,4 @@ RUN curl --location "https://github.com/docker/compose/releases/download/1.29.2/
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-v1 1 && \
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-switch 99
 
-USER coder
+USER 1000

--- a/images/debian/minimal/bullseye/Dockerfile
+++ b/images/debian/minimal/bullseye/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/library/debian:bullseye
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 # Copy configuration files to appropriate locations
 COPY files /
@@ -30,4 +30,4 @@ RUN useradd coder \
       --uid=1000 \
       --user-group
 
-USER coder
+USER 1000

--- a/images/debian/minimal/testing/Dockerfile
+++ b/images/debian/minimal/testing/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/library/debian:testing
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 # Copy configuration files to appropriate locations
 COPY files /
@@ -30,4 +30,4 @@ RUN useradd coder \
       --uid=1000 \
       --user-group
 
-USER coder
+USER 1000

--- a/images/debian/minimal/unstable/Dockerfile
+++ b/images/debian/minimal/unstable/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/library/debian:unstable
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 # Copy configuration files to appropriate locations
 COPY files /
@@ -30,4 +30,4 @@ RUN useradd coder \
       --uid=1000 \
       --user-group
 
-USER coder
+USER 1000

--- a/images/fedora/base/35/Dockerfile
+++ b/images/fedora/base/35/Dockerfile
@@ -7,7 +7,7 @@ FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 # Copy configuration files to appropriate locations
 COPY files /
@@ -34,4 +34,4 @@ RUN curl --location "https://github.com/docker/compose/releases/download/1.29.2/
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-v1 1 && \
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-switch 99
 
-USER coder
+USER 1000

--- a/images/fedora/base/rawhide/Dockerfile
+++ b/images/fedora/base/rawhide/Dockerfile
@@ -7,7 +7,7 @@ FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 # Copy configuration files to appropriate locations
 COPY files /
@@ -34,4 +34,4 @@ RUN curl --location "https://github.com/docker/compose/releases/download/1.29.2/
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-v1 1 && \
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-switch 99
 
-USER coder
+USER 1000

--- a/images/fedora/minimal/35/Dockerfile
+++ b/images/fedora/minimal/35/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.fedoraproject.org/fedora:35
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 RUN dnf install --assumeyes --quiet \
       bash \
@@ -19,4 +19,4 @@ RUN useradd coder \
       --uid=1000 \
       --user-group
 
-USER coder
+USER 1000

--- a/images/fedora/minimal/rawhide/Dockerfile
+++ b/images/fedora/minimal/rawhide/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.fedoraproject.org/fedora:rawhide
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 RUN dnf install --assumeyes --quiet \
       bash \
@@ -19,4 +19,4 @@ RUN useradd coder \
       --uid=1000 \
       --user-group
 
-USER coder
+USER 1000

--- a/images/ubi/base/8/Dockerfile
+++ b/images/ubi/base/8/Dockerfile
@@ -7,7 +7,7 @@ FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 # Copy configuration files to appropriate locations
 COPY files /
@@ -39,4 +39,4 @@ RUN curl --location "https://github.com/docker/compose/releases/download/1.29.2/
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-v1 1 && \
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-switch 99
 
-USER coder
+USER 1000

--- a/images/ubi/minimal/8/Dockerfile
+++ b/images/ubi/minimal/8/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi8/ubi:latest
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 RUN dnf install --assumeyes \
       bash \
@@ -19,4 +19,4 @@ RUN useradd coder \
       --uid=1000 \
       --user-group
 
-USER coder
+USER 1000

--- a/images/ubuntu/base/focal/Dockerfile
+++ b/images/ubuntu/base/focal/Dockerfile
@@ -7,7 +7,7 @@ FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 # Copy configuration files to appropriate locations
 COPY files /
@@ -62,4 +62,4 @@ RUN curl --location "https://github.com/docker/compose/releases/download/1.29.2/
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-v1 1 && \
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-switch 99
 
-USER coder
+USER 1000

--- a/images/ubuntu/base/jammy/Dockerfile
+++ b/images/ubuntu/base/jammy/Dockerfile
@@ -7,7 +7,7 @@ FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 # Copy configuration files to appropriate locations
 COPY files /
@@ -62,4 +62,4 @@ RUN curl --location "https://github.com/docker/compose/releases/download/1.29.2/
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-v1 1 && \
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-switch 99
 
-USER coder
+USER 1000

--- a/images/ubuntu/base/rolling/Dockerfile
+++ b/images/ubuntu/base/rolling/Dockerfile
@@ -7,7 +7,7 @@ FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG}
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 # Copy configuration files to appropriate locations
 COPY files /
@@ -62,4 +62,4 @@ RUN curl --location "https://github.com/docker/compose/releases/download/1.29.2/
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-v1 1 && \
     update-alternatives --install /usr/local/bin/docker-compose docker-compose /usr/local/bin/docker-compose-switch 99
 
-USER coder
+USER 1000

--- a/images/ubuntu/minimal/focal/Dockerfile
+++ b/images/ubuntu/minimal/focal/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/library/ubuntu:focal
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 # Copy configuration files to appropriate locations
 COPY files /
@@ -30,4 +30,4 @@ RUN useradd coder \
       --uid=1000 \
       --user-group
 
-USER coder
+USER 1000

--- a/images/ubuntu/minimal/jammy/Dockerfile
+++ b/images/ubuntu/minimal/jammy/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/library/ubuntu:jammy
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 # Copy configuration files to appropriate locations
 COPY files /
@@ -30,4 +30,4 @@ RUN useradd coder \
       --uid=1000 \
       --user-group
 
-USER coder
+USER 1000

--- a/images/ubuntu/minimal/rolling/Dockerfile
+++ b/images/ubuntu/minimal/rolling/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/library/ubuntu:rolling
 
 SHELL ["/bin/bash", "-c"]
 
-USER root
+USER 0
 
 # Copy configuration files to appropriate locations
 COPY files /
@@ -30,4 +30,4 @@ RUN useradd coder \
       --uid=1000 \
       --user-group
 
-USER coder
+USER 1000


### PR DESCRIPTION
Use numeric USER statements in Dockerfile, as container runtimes
need this to ensure that containers are not running as root.